### PR TITLE
Add Code Like a Pro to Manning book list

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ The license for this resource is [![CC0](https://licensebuttons.net/l/zero/1.0/8
 * [The Quick Python Book, Third Edition](https://www.manning.com/books/the-quick-python-book-third-edition)
 * [Learn Programming with Python](https://www.manning.com/books/learn-programming-with-python)
 * [Grokking Algorithms](https://www.manning.com/books/grokking-algorithms) - An illustrated guide for programmers and other curious people.
+* [Code Like a Pro: Software Development in Python](https://www.manning.com/books/code-like-a-pro) - Professional software development principles and best practices for beginning developers.
 
 ### No Starch Press
 


### PR DESCRIPTION
Hey José, I'm working on a new book for Manning called [_Code Like a Pro: Software Development in Python_](https://www.manning.com/books/code-like-a-pro) that I would be humbled to have added to this list! The goal with this book is to introduce some professional software development concepts to those without formal/traditional software development education. The book is currently in early access, which means I'd love anyone with interest to give feedback on it as I'm writing. If you wish to wait until the book is done to include it (or not at all, of course!) I totally understand!