### PR TITLE
Fix Practical Python Programming and Dabeaz LLC urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Sparkline (GitHub stars velocity): [![Sparkline](https://stars.medv.io/quobit/aw
 ### Introductions and Tutorials
 
 * [The Hello World Program: Learn Python](https://thehelloworldprogram.com/python/)
-* [Practical Python Programming (course by @dabeaz)])https://github.com/dabeaz-course/practical-python)
+* [Practical Python Programming](https://github.com/dabeaz-course/practical-python) - from [Dabeaz LLC](https://github.com/dabeaz-course)
 * [Introduction to Python](http://introtopython.org/)
 * [NewCoder](http://newcoder.io/)
 * [Python tutorial](https://pythonspot.com/)


### PR DESCRIPTION
Hi, there! i'm Danix, a developer. I saw the Awesome Python in Education README and i see a typo in the Practical Python Programming course and his creator url. For this contribution, i fixed this typo and changed his creator name from dabeaz to Dabeaz LLC, that is the organization where his creator published the course. I hope Awesome Python in Education accept my contribution.